### PR TITLE
Drop self-referencing readme-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
---------------------
---------------------
---------------------
---------------------
-# There is a new home for Caribou Klipper configs - check out https://github.com/Caribou3d/CaribouGoesKlipper
-
---------------------
---------------------
---------------------
---------------------
 # Klipper config for my Caribou 320 mk3s
 
 Forked from https://github.com/Frix-x/klipper-prusa-i3mk3s and modified for my printer - to be used with mainsail.


### PR DESCRIPTION
Dropping the self-reference in the read-me file.